### PR TITLE
eventstream: generics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ jobs:
       - image: cimg/go:1.18
     steps: *simple_job_steps
 
-
   build-1-19:
     working_directory: ~/repo
     docker:
@@ -38,9 +37,9 @@ jobs:
       - checkout
       - run:
           name: Run tests and linters
-        command: |
-          make -C eventstream ci
-          make -C eventstream/test ci
+          command: |
+            make -C eventstream ci
+            make -C eventstream/test ci
 
 workflows:
   pr-build-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,29 +2,50 @@ shared_configs:
   simple_job_steps: &simple_job_steps
     - checkout
     - run:
-        name: Build
+        name: Run tests
         command: |
-          make -C eventstream ci
-          make -C eventstream/test ci
+          make -C eventstream test
+          make -C eventstream/test test
 
 
 # Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
 jobs:
-  build-1-17:
-    working_directory: ~/repo
-    docker:
-      - image: cimg/go:1.17
-    steps: *simple_job_steps
-
   build-1-18:
     working_directory: ~/repo
     docker:
       - image: cimg/go:1.18
     steps: *simple_job_steps
 
+
+  build-1-19:
+    working_directory: ~/repo
+    docker:
+      - image: cimg/go:1.19
+    steps: *simple_job_steps
+
+  build-1-20:
+    working_directory: ~/repo
+    docker:
+      - image: cimg/go:1.20
+    steps: *simple_job_steps
+
+  build-1-21:
+    working_directory: ~/repo
+    docker:
+      - image: cimg/go:1.21
+    steps:
+      - checkout
+      - run:
+          name: Run tests and linters
+        command: |
+          make -C eventstream ci
+          make -C eventstream/test ci
+
 workflows:
   pr-build-test:
     jobs:
-      - build-1-17
       - build-1-18
+      - build-1-19
+      - build-1-20
+      - build-1-21

--- a/eventstream/Makefile
+++ b/eventstream/Makefile
@@ -4,10 +4,12 @@ ci: deps checkgofmt vet staticcheck ineffassign predeclared golint errcheck test
 .PHONY: deps
 deps:
 	go get -d -v -t ./...
+	go mod tidy
 
 .PHONY: updatedeps
 updatedeps:
 	go get -d -v -t -u -f ./...
+	go mod tidy
 
 .PHONY: checkgofmt
 checkgofmt:
@@ -18,11 +20,11 @@ checkgofmt:
 
 .PHONY: vet
 vet:
-	go vet -composites=false ./...
+	go vet
 
 .PHONY: staticcheck
 staticcheck:
-	@go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
+	@go install honnef.co/go/tools/cmd/staticcheck@v0.4.3
 	staticcheck ./...
 
 .PHONY: ineffassign
@@ -47,4 +49,5 @@ errcheck:
 
 .PHONY: test
 test:
-	$(MAKE) -C test
+	# The race detector requires CGO: https://github.com/golang/go/issues/6508
+	CGO_ENABLED=1 go test -race ./...

--- a/eventstream/go.mod
+++ b/eventstream/go.mod
@@ -1,3 +1,3 @@
 module github.com/fullstorydev/go/eventstream
 
-go 1.15
+go 1.18

--- a/eventstream/interface.go
+++ b/eventstream/interface.go
@@ -54,7 +54,7 @@ type Iterator[T any] interface {
 	// Blocks until one of these three outcomes occurs.
 	Next(ctx context.Context) (T, error)
 
-	// Consume iterates the remained of the stream, calling the provided callback with each successive value.
+	// Consume iterates the remainder of the stream, calling the provided callback with each successive value.
 	// - Returns (nil) when the stream is exhausted.
 	// - Returns (ctx.Err()) if the context is cancelled.
 	// - Returns (<error>) if the callback returns any non-nil error.

--- a/eventstream/interface.go
+++ b/eventstream/interface.go
@@ -55,9 +55,9 @@ type Iterator[T any] interface {
 	Next(ctx context.Context) (T, error)
 
 	// Consume iterates the remainder of the stream, calling the provided callback with each successive value.
-	// - Returns (nil) when the stream is exhausted.
-	// - Returns (ctx.Err()) if the context is cancelled.
-	// - Returns (<error>) if the callback returns any non-nil error.
+	// - Returns `nil` when the stream is exhausted, or if the callback returns ErrDone.
+	// - Returns `<error>` if the callback returns any other non-nil error.
+	// - Returns `ctx.Err()` if the context is cancelled.
 	// Blocks until one of these three outcomes occurs.
 	Consume(ctx context.Context, callback func(context.Context, T) error) error
 }

--- a/eventstream/interface.go
+++ b/eventstream/interface.go
@@ -53,4 +53,11 @@ type Iterator[T any] interface {
 	// - Returns (zero, ctx.Err()) if the context is cancelled.
 	// Blocks until one of these three outcomes occurs.
 	Next(ctx context.Context) (T, error)
+
+	// Consume iterates the remained of the stream, calling the provided callback with each successive value.
+	// - Returns (nil) when the stream is exhausted.
+	// - Returns (ctx.Err()) if the context is cancelled.
+	// - Returns (<error>) if the callback returns any non-nil error.
+	// Blocks until one of these three outcomes occurs.
+	Consume(ctx context.Context, callback func(context.Context, T) error) error
 }

--- a/eventstream/interface.go
+++ b/eventstream/interface.go
@@ -9,35 +9,35 @@ import (
 // EventStream allows a single producer to publish events to multiple asynchronous consumers, who each
 // receive all events. Note that event values are opaque to the event stream and no copies are made:
 // consumers should not mutate consumed event values!
-type EventStream interface {
+type EventStream[T any] interface {
 	// Publish adds the next value to the stream. This method can be called concurrently with subscriber reads,
 	// but not with other publisher operations.  External synchronization is required if there are multiple concurrent
 	// publishers.
-	Publish(interface{})
+	Publish(T)
 
 	// Close ends the stream; the same concurrency rules apply to Close() and Publish().
 	Close()
 
 	// Subscribe returns a Promise to the next unpublished event. The returned Promise gives the caller
 	// the events in the stream from the current position forward.
-	Subscribe() Promise
+	Subscribe() Promise[T]
 }
 
 // Promise is a handle to the next event in the stream, plus all events following.
 // A Promise is effectively immutable and can be shared. To be used concurrently with Publish operations.
-type Promise interface {
+type Promise[T any] interface {
 	// Ready returns the ready channel for this node; the channel closes when this Promise is ready.
 	Ready() <-chan struct{}
 
 	// Next returns the next event in the stream, and the next Promise.  Multiple calls return consistent results.
-	// Returns (nil, nil) when the stream is Closed.
+	// Returns (zero, nil) when the stream is Closed.
 	//
 	// Note that this method internally blocks until the Ready() channel is closed!
 	// Typical callers will not call Next() until this Promise is ready.
-	Next() (interface{}, Promise)
+	Next() (T, Promise[T])
 
 	// Iterator creates an Iterator based on this Promise.  The Promise is unchanged.
-	Iterator() Iterator
+	Iterator() Iterator[T]
 }
 
 // ErrDone is returned by Iterator.Next() when the underlying EventStream is closed.
@@ -46,11 +46,11 @@ var ErrDone = errors.New("no more items in iterator")
 // Iterator iterates an event stream.  To be used concurrently with Publish operations.
 //
 // Unlike Promises, Iterators are stateful and should not be shared across go routines.
-type Iterator interface {
+type Iterator[T any] interface {
 	// Next returns the next event in the stream.
 	// - Returns (<event>, nil) when the next event is published.
-	// - Returns (nil, ErrDone) when the stream is exhausted.
-	// - Returns (nil, ctx.Err()) if the context is cancelled.
+	// - Returns (zero, ErrDone) when the stream is exhausted.
+	// - Returns (zero, ctx.Err()) if the context is cancelled.
 	// Blocks until one of these three outcomes occurs.
-	Next(ctx context.Context) (interface{}, error)
+	Next(ctx context.Context) (T, error)
 }

--- a/eventstream/iterator.go
+++ b/eventstream/iterator.go
@@ -29,3 +29,17 @@ func (it *iterator[T]) Next(ctx context.Context) (T, error) {
 		return zero, ctx.Err()
 	}
 }
+
+func (it *iterator[T]) Consume(ctx context.Context, callback func(context.Context, T) error) error {
+	for {
+		val, err := it.Next(ctx)
+		if err == ErrDone {
+			return nil
+		} else if err != nil {
+			return err
+		}
+		if err := callback(ctx, val); err != nil {
+			return err
+		}
+	}
+}

--- a/eventstream/iterator.go
+++ b/eventstream/iterator.go
@@ -2,6 +2,7 @@ package eventstream
 
 import (
 	"context"
+	"errors"
 )
 
 type iterator[T any] struct {
@@ -32,14 +33,17 @@ func (it *iterator[T]) Next(ctx context.Context) (T, error) {
 
 func (it *iterator[T]) Consume(ctx context.Context, callback func(context.Context, T) error) error {
 	for {
-		val, err := it.Next(ctx)
-		if err == ErrDone {
-			return nil
-		} else if err != nil {
-			return err
-		}
-		if err := callback(ctx, val); err != nil {
-			return err
+		if val, err := it.Next(ctx); err != nil {
+			return filterErrDone(err)
+		} else if err = callback(ctx, val); err != nil {
+			return filterErrDone(err)
 		}
 	}
+}
+
+func filterErrDone(err error) error {
+	if errors.Is(err, ErrDone) {
+		return nil
+	}
+	return err
 }

--- a/eventstream/iterator.go
+++ b/eventstream/iterator.go
@@ -4,16 +4,17 @@ import (
 	"context"
 )
 
-type iterator struct {
-	p Promise
+type iterator[T any] struct {
+	p Promise[T]
 }
 
-func (it *iterator) Next(ctx context.Context) (interface{}, error) {
+func (it *iterator[T]) Next(ctx context.Context) (T, error) {
+	var zero T
 	if it.p == nil {
-		return nil, ErrDone
+		return zero, ErrDone
 	}
 	if err := ctx.Err(); err != nil {
-		return nil, err
+		return zero, err
 	}
 
 	select {
@@ -21,10 +22,10 @@ func (it *iterator) Next(ctx context.Context) (interface{}, error) {
 		v, p := it.p.Next()
 		it.p = p
 		if p == nil {
-			return nil, ErrDone
+			return zero, ErrDone
 		}
 		return v, nil
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return zero, ctx.Err()
 	}
 }

--- a/eventstream/node.go
+++ b/eventstream/node.go
@@ -1,16 +1,16 @@
 package eventstream
 
-type node struct {
-	value interface{}   // the value of the event (nil until ready)
-	next  *node         // the next node in the stream (nil until ready)
+type node[T any] struct {
+	value T             // the value of the event (zero until ready)
+	next  *node[T]      // the next node in the stream (nil until ready)
 	ready chan struct{} // a channel whose closure marks readiness
 }
 
-func (n *node) Ready() <-chan struct{} {
+func (n *node[T]) Ready() <-chan struct{} {
 	return n.ready
 }
 
-func (n *node) Next() (interface{}, Promise) {
+func (n *node[T]) Next() (T, Promise[T]) {
 	<-n.ready
 	if n.next == nil {
 		// force nil interface
@@ -19,14 +19,14 @@ func (n *node) Next() (interface{}, Promise) {
 	return n.value, n.next
 }
 
-func (n *node) Iterator() Iterator {
-	return &iterator{p: n}
+func (n *node[T]) Iterator() Iterator[T] {
+	return &iterator[T]{p: n}
 }
 
-func (n *node) makeReady(v interface{}, next *node) {
+func (n *node[T]) makeReady(v T, next *node[T]) {
 	n.value = v
 	n.next = next
 	close(n.ready)
 }
 
-var _ Promise = (*node)(nil)
+var _ Promise[any] = (*node[any])(nil)

--- a/eventstream/test/Makefile
+++ b/eventstream/test/Makefile
@@ -4,10 +4,12 @@ ci: deps checkgofmt vet staticcheck ineffassign predeclared golint errcheck test
 .PHONY: deps
 deps:
 	go get -d -v -t ./...
+	go mod tidy
 
 .PHONY: updatedeps
 updatedeps:
 	go get -d -v -t -u -f ./...
+	go mod tidy
 
 .PHONY: checkgofmt
 checkgofmt:
@@ -18,11 +20,11 @@ checkgofmt:
 
 .PHONY: vet
 vet:
-	go vet -composites=false ./...
+	go vet
 
 .PHONY: staticcheck
 staticcheck:
-	@go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
+	@go install honnef.co/go/tools/cmd/staticcheck@v0.4.3
 	staticcheck ./...
 
 .PHONY: ineffassign

--- a/eventstream/test/eventstream_test.go
+++ b/eventstream/test/eventstream_test.go
@@ -13,10 +13,10 @@ func TestEventStream_Serial(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	es := eventstream.NewWithBuffer(16) // small buffer so we exercise rolling over
+	es := eventstream.NewWithBuffer[int](16) // small buffer so we exercise rolling over
 
 	it1 := es.Subscribe().Iterator() // sees everything
-	var it2 eventstream.Iterator
+	var it2 eventstream.Iterator[int]
 	for i := 0; i < 100; i++ {
 		if i == 50 {
 			it2 = es.Subscribe().Iterator() // sees 50 - 99
@@ -30,14 +30,14 @@ func TestEventStream_Serial(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		v, err := it1.Next(ctx)
 		assert.NilError(t, err, "should not err")
-		assert.Equal(t, i, v.(int), "wrong")
+		assert.Equal(t, i, v, "wrong")
 	}
 	assertDone(ctx, t, it1)
 
 	for i := 50; i < 100; i++ {
 		v, err := it2.Next(ctx)
 		assert.NilError(t, err, "should not err")
-		assert.Equal(t, i, v.(int), "wrong")
+		assert.Equal(t, i, v, "wrong")
 	}
 	assertDone(ctx, t, it2)
 
@@ -50,14 +50,14 @@ func TestEventStream_Concurrent(t *testing.T) {
 	defer cancel()
 	g, ctx := errgroup.WithContext(ctx)
 
-	es := eventstream.NewWithBuffer(16) // small buffer so we exercise rolling over
+	es := eventstream.NewWithBuffer[int](16) // small buffer so we exercise rolling over
 
 	itEverything := es.Subscribe().Iterator() // sees everything
 	g.Go(func() error {
 		for i := 0; i < 100; i++ {
 			v, err := itEverything.Next(ctx)
 			assert.NilError(t, err)
-			assert.Equal(t, i, v.(int))
+			assert.Equal(t, i, v)
 		}
 		assertDone(ctx, t, itEverything)
 		return nil
@@ -70,7 +70,7 @@ func TestEventStream_Concurrent(t *testing.T) {
 				for i := 50; i < 100; i++ {
 					v, err := itHalf.Next(ctx)
 					assert.NilError(t, err)
-					assert.Equal(t, i, v.(int))
+					assert.Equal(t, i, v)
 				}
 				assertDone(ctx, t, itHalf)
 				return nil
@@ -93,9 +93,9 @@ func TestEventStream_Concurrent(t *testing.T) {
 	assert.NilError(t, g.Wait())
 }
 
-func assertDone(ctx context.Context, t *testing.T, p eventstream.Iterator) {
+func assertDone(ctx context.Context, t *testing.T, p eventstream.Iterator[int]) {
 	t.Helper()
 	v, err := p.Next(ctx)
-	assert.Assert(t, v == nil)
+	assert.Assert(t, v == 0)
 	assert.Equal(t, eventstream.ErrDone, err)
 }

--- a/eventstream/test/go.mod
+++ b/eventstream/test/go.mod
@@ -1,11 +1,16 @@
 module github.com/fullstorydev/go/eventstream/test
 
-go 1.15
+go 1.18
 
 require (
 	github.com/fullstorydev/go/eventstream v0.0.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	gotest.tools/v3 v3.0.3
+)
+
+require (
+	github.com/google/go-cmp v0.4.0 // indirect
+	github.com/pkg/errors v0.8.1 // indirect
 )
 
 replace github.com/fullstorydev/go/eventstream => ./..


### PR DESCRIPTION
FWIW, this will break compatibility, but since we're a low-usage library on v0 versioning, I think this is fine.